### PR TITLE
🏗  [just] add hugo subcommand

### DIFF
--- a/justfile
+++ b/justfile
@@ -77,6 +77,11 @@ hugo_mod_update:
 prweb: on_a_branch
     gh pr view --web
 
+# run hugo from the top of the repo
+[group('Process')]
+hugo:
+    hugo
+
 #test: on_a_branch
 #  echo gh pr create --title "{{last_commit_message}}" --body "{{last_commit_message}}\nAutomated in 'justfile'."
 # TODO: sanity check for making sure there are commits on the branch


### PR DESCRIPTION
# what

* 🏗  [just] add hugo subcommand 

# why

When you are deep into the repo making content changes and you run `hugo` you get a suspicious error message:

    Total in 4 ms
    Error: Unable to locate config file or config directory. Perhaps you need to create a new site.
    Run `hugo help new` for details.

Since you *know* you're already in a hugo site, this is not a helpful suggestion.  I do not need to create a new site.  I just want `hugo` to run on the current site.  Well, `just` take cares of this because it runs commands from the root of the tree by default.  So just sticking this into `just` makes it handier despite it just running the same command with no options. Maybe I'll find more magic to add at generation time someday and add that in.

# meta

(Automated in `justfile`.)