### PR TITLE
🧼 [just] keep a clean repo by deleting merged branches

### DIFF
--- a/justfile
+++ b/justfile
@@ -71,7 +71,7 @@ pr: on_a_branch
 # merge PR and return to starting point
 [group('Process')]
 merge:
-    gh pr merge -s
+    gh pr merge -s -d
     just sync
 
 # start a new post


### PR DESCRIPTION
## Done:

- 🧼 [just] keep a clean repo by deleting merged branches


(Automated in `justfile`.)
