### PR TITLE
🚥 [just] better error message when tmpdir still exists in [32mno public.prev directory, so safe to rebuild with hugo...[0m
Start building sites … 
hugo v0.138.0+extended+withdeploy darwin/arm64 BuildDate=2024-11-06T11:22:34Z VendorInfo=brew


                   | EN   
-------------------+------
  Pages            | 161  
  Paginator pages  |   5  
  Non-page files   |   6  
  Static files     |  11  
  Processed images |   0  
  Aliases          |  48  
  Cleaned          |   0  

Total in 88 ms
 M TODO.md
?? .fini/ run

### DIFF
--- a/justfile
+++ b/justfile
@@ -108,8 +108,12 @@ prweb: on_a_branch
 [group('Hugo')]
 hugo:
     #!/usr/bin/env bash
-    [[ -e public.prev ]] && exit 5
-    echo "{{GREEN}}no prev directory, so safe to rebuild with hugo...{{NORMAL}}"
+    PREV_DIR="public.prev"
+    if [[ -e "$PREV_DIR" ]]; then
+        echo "{{RED}}The $PREV_DIR directory exists.  Is there a bug on a previous hugo run?{{NORMAL}}"
+        exit 5
+    fi
+    echo "{{GREEN}}no $PREV_DIR directory, so safe to rebuild with hugo...{{NORMAL}}"
 
     set -euxo pipefail # strict mode
 


### PR DESCRIPTION
## Done:

- 🚥 [just] better error message when tmpdir still exists in [32mno public.prev directory, so safe to rebuild with hugo...[0m
Start building sites … 
hugo v0.138.0+extended+withdeploy darwin/arm64 BuildDate=2024-11-06T11:22:34Z VendorInfo=brew


                   | EN   
-------------------+------
  Pages            | 161  
  Paginator pages  |   5  
  Non-page files   |   6  
  Static files     |  11  
  Processed images |   0  
  Aliases          |  48  
  Cleaned          |   0  

Total in 104 ms
 M TODO.md
?? .fini/ run


(Automated in `justfile`.)
