### PR TITLE
🐐 [post] How Rust Had to Save Python From Itself: The uv Revolution

### DIFF
--- a/content/posts/2025-09-04-uv-is-awesome.md
+++ b/content/posts/2025-09-04-uv-is-awesome.md
@@ -1,0 +1,102 @@
++++
+title = 'How Rust Had to Save Python From Itself: The uv Revolution'
+date = 2025-09-04
+draft = false
+description = 'Rust saves the bacon for python packaging and formatting.'
+cover.hidden = true
+# keywords = ["", "", ""]
+# tags = ["", "", "", ""]
+ShowToc = true
++++
+
+Well, well, well. Here we are in 2025 and Python packaging has finally been
+fixed. Not by the Python community, mind you - they had their shot for about
+20 years. No, it took the Rust folks to come in and show us how it's done.
+
+## The Long, Painful History
+
+Let me paint you a picture. Back when I was starting out, we had `distutils`.
+That was it. Then came `setuptools`, which was supposed to fix everything.
+Then `pip` showed up to handle installation. Then `virtualenv` because global
+package installs were a nightmare. Then `pipenv` to combine pip and
+virtualenv. Then `poetry` because pipenv wasn't quite right. Then `pip-tools`
+for deterministic builds. Then `conda` for scientific computing. Then...
+
+You get the idea. Each tool solved one specific problem while creating three
+new ones. The Python community spent decades bikeshedding over package
+formats, dependency resolution algorithms, and lock file formats while the
+rest of the world just wanted to install packages without breaking their
+system. Some tools even managed to break the ancient Unix standard of
+shebang lines - you know, that `#!/usr/bin/env python` thing that's been
+working since the dawn of time.
+
+## The Delusion
+
+Here's the thing that drives me nuts: the Python community kept insisting
+they could solve this from within. "We just need better standards!" they'd
+cry. "PEP 517 will fix everything!" Narrator: it didn't. "PEP 621 is the
+answer!" Still waiting on that revolution.
+
+Meanwhile, every other modern language figured this out ages ago.
+[Cargo](https://doc.rust-lang.org/cargo/) for
+[Rust](https://www.rust-lang.org/). [Go modules](https://go.dev/ref/mod).
+[npm](https://www.npmjs.com/) (despite its flaws) for
+[JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript). Even
+Perl got [CPAN](https://www.cpan.org/) right decades ago! But Python? Python
+kept spawning new tools that partially solved the problem while maintaining
+backward compatibility with decades of technical debt.
+
+## Enter uv: Rust to the Rescue
+
+Then along comes [Astral](https://astral.sh/) with
+[`uv`](https://docs.astral.sh/uv/), written in
+[Rust](https://www.rust-lang.org/), and suddenly everything just... works.
+It's fast. Like, stupidly fast. It handles virtual environments
+transparently. It resolves dependencies without making you wait for your
+coffee to brew. It installs packages so quickly you wonder if it actually did
+anything.
+
+The best part? They didn't try to be compatible with every broken decision
+the Python packaging ecosystem made over the past two decades. They looked at
+what actually needed to be solved and built a tool that solves those
+problems.
+
+## The Irony
+
+The delicious irony here is that it took a systems programming language to
+fix a scripting language's package management. Rust's obsession with memory
+safety and performance optimization turns out to be exactly what Python's
+packaging ecosystem needed. Who could have predicted that?
+
+It's like watching someone struggle to open a jar for 20 years, refusing help
+from anyone, only to have their neighbor walk over with the right tool and
+pop it open in two seconds.
+
+## What This Means
+
+For those of us who've been dealing with Python packaging hell since the
+`easy_install` days, `uv` feels like a miracle. One tool that does
+everything, does it fast, and doesn't break when you look at it sideways.
+Release engineers everywhere can finally sleep soundly knowing their builds
+won't randomly break because of dependency resolution conflicts or virtual
+environment corruption.
+
+The Python community should probably feel a little embarrassed about this.
+Twenty years of "we can fix this ourselves" only to be shown up by a tool
+written in a different language entirely. But hey, at least we finally have
+something that works.
+
+So here's to the Rust community for doing what the Python community couldn't:
+fixing Python packaging. Sometimes you need an outsider's perspective to see
+the forest for the trees. Or in this case, to see the solution through all
+the PEPs.
+
+Now if you'll excuse me, I need to go update all my projects to use `uv`. It
+only takes about 30 seconds per project, which is another miracle in itself.
+The best part? My colleagues independently discovered `uv` around the same
+time I did - that's how you know a tool is genuinely solving real problems
+when multiple people stumble across it organically.
+
+## My post on linked-in
+
+- coming soon

--- a/public/archives/index.html
+++ b/public/archives/index.html
@@ -188,8 +188,22 @@
 <div class="archive-year">
   <h2 class="archive-year-header" id="2025">
     <a class="archive-header-link" href="#2025">2025</a>
-    <sup class="archive-count">&nbsp;8</sup>
+    <sup class="archive-count">&nbsp;9</sup>
   </h2>
+  <div class="archive-month">
+    <h3 class="archive-month-header" id="2025-September">
+      <a class="archive-header-link" href="#2025-September">September</a>
+      <sup class="archive-count">&nbsp;1</sup>
+    </h3>
+    <div class="archive-posts">
+      <div class="archive-entry">
+        <h3 class="archive-entry-title entry-hint-parent">How Rust Had to Save Python From Itself: The uv Revolution
+        </h3>
+        <div class="archive-meta"><span title='2025-09-04 00:00:00 +0000 UTC'>September 4, 2025</span>&nbsp;·&nbsp;4 min&nbsp;·&nbsp;673 words&nbsp;·&nbsp;Christopher Hicks</div>
+        <a class="entry-link" aria-label="post link to How Rust Had to Save Python From Itself: The uv Revolution" href="/posts/2025-09-04-uv-is-awesome/"></a>
+      </div>
+    </div>
+  </div>
   <div class="archive-month">
     <h3 class="archive-month-header" id="2025-August">
       <a class="archive-header-link" href="#2025-August">August</a>

--- a/public/categories/index.xml
+++ b/public/categories/index.xml
@@ -4,7 +4,7 @@
     <title>Categories on Christopher Hicks</title>
     <link>/categories/</link>
     <description>Recent content in Categories on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <atom:link href="/categories/index.xml" rel="self" type="application/rss+xml" />
   </channel>

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="auto">
 
 <head>
-	<meta name="generator" content="Hugo 0.148.1"><meta charset="utf-8">
+	<meta name="generator" content="Hugo 0.149.0"><meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="robots" content="index, follow">

--- a/public/index.xml
+++ b/public/index.xml
@@ -4,10 +4,17 @@
     <title>Christopher Hicks on the web on Christopher Hicks</title>
     <link>/</link>
     <description>Recent content in Christopher Hicks on the web on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
-    <lastBuildDate>Fri, 22 Aug 2025 00:00:00 +0000</lastBuildDate>
+    <lastBuildDate>Thu, 04 Sep 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>How Rust Had to Save Python From Itself: The uv Revolution</title>
+      <link>/posts/2025-09-04-uv-is-awesome/</link>
+      <pubDate>Thu, 04 Sep 2025 00:00:00 +0000</pubDate>
+      <guid>/posts/2025-09-04-uv-is-awesome/</guid>
+      <description>Rust saves the bacon for python packaging and formatting.</description>
+    </item>
     <item>
       <title>John Schreiber passed on July 29th, 2025</title>
       <link>/posts/2025-08-24-john-schreiber-has-passed/</link>

--- a/public/intro/index.xml
+++ b/public/intro/index.xml
@@ -4,7 +4,7 @@
     <title>Introduction to Christopher Hicks on Christopher Hicks</title>
     <link>/intro/</link>
     <description>Recent content in Introduction to Christopher Hicks on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate></lastBuildDate>
     <atom:link href="/intro/index.xml" rel="self" type="application/rss+xml" />

--- a/public/links/index.xml
+++ b/public/links/index.xml
@@ -4,7 +4,7 @@
     <title>Christopher Hicks links on Christopher Hicks</title>
     <link>/links/</link>
     <description>Recent content in Christopher Hicks links on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Sun, 30 Jun 2024 00:00:00 +0000</lastBuildDate>
     <atom:link href="/links/index.xml" rel="self" type="application/rss+xml" />

--- a/public/posts/2025-09-04-uv-is-awesome/index.html
+++ b/public/posts/2025-09-04-uv-is-awesome/index.html
@@ -1,0 +1,439 @@
+<!DOCTYPE html>
+<html lang="en" dir="auto">
+
+<head><meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta name="robots" content="index, follow">
+<title>How Rust Had to Save Python From Itself: The uv Revolution | Christopher Hicks</title>
+<meta name="keywords" content="">
+<meta name="description" content="Rust saves the bacon for python packaging and formatting.">
+<meta name="author" content="Christopher Hicks">
+<link rel="canonical" href="/posts/2025-09-04-uv-is-awesome/">
+<link crossorigin="anonymous" href="/assets/css/stylesheet.8fe10233a706bc87f2e08b3cf97b8bd4c0a80f10675a143675d59212121037c0.css" integrity="sha256-j&#43;ECM6cGvIfy4Is8&#43;XuL1MCoDxBnWhQ2ddWSEhIQN8A=" rel="preload stylesheet" as="style">
+<link rel="icon" href="/favicon.ico">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="mask-icon" href="/safari-pinned-tab.svg">
+<meta name="theme-color" content="#a903fc">
+<meta name="msapplication-TileColor" content="#2e2e33">
+<link rel="alternate" hreflang="en" href="/posts/2025-09-04-uv-is-awesome/">
+<noscript>
+    <style>
+        #theme-toggle,
+        .top-link {
+            display: none;
+        }
+
+    </style>
+    <style>
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --theme: rgb(29, 30, 32);
+                --entry: rgb(46, 46, 51);
+                --primary: rgb(218, 218, 219);
+                --secondary: rgb(155, 156, 157);
+                --tertiary: rgb(65, 66, 68);
+                --content: rgb(196, 196, 197);
+                --code-block-bg: rgb(46, 46, 51);
+                --code-bg: rgb(55, 56, 62);
+                --border: rgb(51, 51, 51);
+            }
+
+            .list {
+                background: var(--theme);
+            }
+
+            .list:not(.dark)::-webkit-scrollbar-track {
+                background: 0 0;
+            }
+
+            .list:not(.dark)::-webkit-scrollbar-thumb {
+                border-color: var(--theme);
+            }
+        }
+
+    </style>
+</noscript><meta property="og:url" content="/posts/2025-09-04-uv-is-awesome/">
+  <meta property="og:site_name" content="Christopher Hicks">
+  <meta property="og:title" content="How Rust Had to Save Python From Itself: The uv Revolution">
+  <meta property="og:description" content="Rust saves the bacon for python packaging and formatting.">
+  <meta property="og:locale" content="en-us">
+  <meta property="og:type" content="article">
+    <meta property="article:section" content="posts">
+    <meta property="article:published_time" content="2025-09-04T00:00:00+00:00">
+    <meta property="article:modified_time" content="2025-09-04T00:00:00+00:00">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="How Rust Had to Save Python From Itself: The uv Revolution">
+<meta name="twitter:description" content="Rust saves the bacon for python packaging and formatting.">
+
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position":  1 ,
+      "name": "Posts",
+      "item": "/posts/"
+    }
+    {
+      "@type": "ListItem",
+      "position":  1 ,
+      "name": "How Rust Had to Save Python From Itself: The uv Revolution",
+      "item": "/posts/2025-09-04-uv-is-awesome/"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "How Rust Had to Save Python From Itself: The uv Revolution",
+  "name": "How Rust Had to Save Python From Itself: The uv Revolution",
+  "description": "Rust saves the bacon for python packaging and formatting.",
+  "keywords": [
+    
+  ],
+  "articleBody": "Well, well, well. Here we are in 2025 and Python packaging has finally been fixed. Not by the Python community, mind you - they had their shot for about 20 years. No, it took the Rust folks to come in and show us how it’s done.\nThe Long, Painful History Let me paint you a picture. Back when I was starting out, we had distutils. That was it. Then came setuptools, which was supposed to fix everything. Then pip showed up to handle installation. Then virtualenv because global package installs were a nightmare. Then pipenv to combine pip and virtualenv. Then poetry because pipenv wasn’t quite right. Then pip-tools for deterministic builds. Then conda for scientific computing. Then…\nYou get the idea. Each tool solved one specific problem while creating three new ones. The Python community spent decades bikeshedding over package formats, dependency resolution algorithms, and lock file formats while the rest of the world just wanted to install packages without breaking their system. Some tools even managed to break the ancient Unix standard of shebang lines - you know, that #!/usr/bin/env python thing that’s been working since the dawn of time.\nThe Delusion Here’s the thing that drives me nuts: the Python community kept insisting they could solve this from within. “We just need better standards!” they’d cry. “PEP 517 will fix everything!” Narrator: it didn’t. “PEP 621 is the answer!” Still waiting on that revolution.\nMeanwhile, every other modern language figured this out ages ago. Cargo for Rust. Go modules. npm (despite its flaws) for JavaScript. Even Perl got CPAN right decades ago! But Python? Python kept spawning new tools that partially solved the problem while maintaining backward compatibility with decades of technical debt.\nEnter uv: Rust to the Rescue Then along comes Astral with uv, written in Rust, and suddenly everything just… works. It’s fast. Like, stupidly fast. It handles virtual environments transparently. It resolves dependencies without making you wait for your coffee to brew. It installs packages so quickly you wonder if it actually did anything.\nThe best part? They didn’t try to be compatible with every broken decision the Python packaging ecosystem made over the past two decades. They looked at what actually needed to be solved and built a tool that solves those problems.\nThe Irony The delicious irony here is that it took a systems programming language to fix a scripting language’s package management. Rust’s obsession with memory safety and performance optimization turns out to be exactly what Python’s packaging ecosystem needed. Who could have predicted that?\nIt’s like watching someone struggle to open a jar for 20 years, refusing help from anyone, only to have their neighbor walk over with the right tool and pop it open in two seconds.\nWhat This Means For those of us who’ve been dealing with Python packaging hell since the easy_install days, uv feels like a miracle. One tool that does everything, does it fast, and doesn’t break when you look at it sideways. Release engineers everywhere can finally sleep soundly knowing their builds won’t randomly break because of dependency resolution conflicts or virtual environment corruption.\nThe Python community should probably feel a little embarrassed about this. Twenty years of “we can fix this ourselves” only to be shown up by a tool written in a different language entirely. But hey, at least we finally have something that works.\nSo here’s to the Rust community for doing what the Python community couldn’t: fixing Python packaging. Sometimes you need an outsider’s perspective to see the forest for the trees. Or in this case, to see the solution through all the PEPs.\nNow if you’ll excuse me, I need to go update all my projects to use uv. It only takes about 30 seconds per project, which is another miracle in itself. The best part? My colleagues independently discovered uv around the same time I did - that’s how you know a tool is genuinely solving real problems when multiple people stumble across it organically.\nMy post on linked-in coming soon ",
+  "wordCount" : "673",
+  "inLanguage": "en",
+  "datePublished": "2025-09-04T00:00:00Z",
+  "dateModified": "2025-09-04T00:00:00Z",
+  "author":{
+    "@type": "Person",
+    "name": "Christopher Hicks"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "/posts/2025-09-04-uv-is-awesome/"
+  },
+  "publisher": {
+    "@type": "Person",
+    "name": "Christopher Hicks",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "/favicon.ico"
+    }
+  }
+}
+</script>
+</head>
+
+<body class="" id="top">
+<script>
+    if (localStorage.getItem("pref-theme") === "dark") {
+        document.body.classList.add('dark');
+    } else if (localStorage.getItem("pref-theme") === "light") {
+        document.body.classList.remove('dark')
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.body.classList.add('dark');
+    }
+
+</script>
+
+<header class="header">
+    <nav class="nav">
+        <div class="logo">
+            <a href="/" accesskey="h" title="Christopher Hicks (Alt + H)">Christopher Hicks</a>
+            <div class="logo-switches">
+                <button id="theme-toggle" accesskey="t" title="(Alt + T)" aria-label="Toggle theme">
+                    <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
+                        fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                        stroke-linejoin="round">
+                        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                    </svg>
+                    <svg id="sun" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
+                        fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                        stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="5"></circle>
+                        <line x1="12" y1="1" x2="12" y2="3"></line>
+                        <line x1="12" y1="21" x2="12" y2="23"></line>
+                        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                        <line x1="1" y1="12" x2="3" y2="12"></line>
+                        <line x1="21" y1="12" x2="23" y2="12"></line>
+                        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <ul id="menu">
+            <li>
+                <a href="/intro" title="Intro">
+                    <span>Intro</span>
+                </a>
+            </li>
+            <li>
+                <a href="/posts" title="Posts">
+                    <span>Posts</span>
+                </a>
+            </li>
+            <li>
+                <a href="/links" title="Links">
+                    <span>Links</span>
+                </a>
+            </li>
+            <li>
+                <a href="/archives" title="Archive">
+                    <span>Archive</span>
+                </a>
+            </li>
+        </ul>
+    </nav>
+</header>
+<main class="main">
+
+<article class="post-single">
+  <header class="post-header">
+    <div class="breadcrumbs"><a href="/">Home</a>&nbsp;»&nbsp;<a href="/posts/">Posts</a></div>
+    <h1 class="post-title entry-hint-parent">
+      How Rust Had to Save Python From Itself: The uv Revolution
+    </h1>
+    <div class="post-description">
+      Rust saves the bacon for python packaging and formatting.
+    </div>
+    <div class="post-meta"><span title='2025-09-04 00:00:00 +0000 UTC'>September 4, 2025</span>&nbsp;·&nbsp;4 min&nbsp;·&nbsp;673 words&nbsp;·&nbsp;Christopher Hicks&nbsp;|&nbsp;<a href="https://github.com/chicks-net/www-chicks-net/tree/main/content/posts/2025-09-04-uv-is-awesome.md" rel="noopener noreferrer edit" target="_blank">Suggest Changes</a>
+
+</div>
+  </header> <div class="toc">
+    <details >
+        <summary accesskey="c" title="(Alt + C)">
+            <span class="details">Table of Contents</span>
+        </summary>
+
+        <div class="inner"><nav id="TableOfContents">
+  <ul>
+    <li><a href="#the-long-painful-history">The Long, Painful History</a></li>
+    <li><a href="#the-delusion">The Delusion</a></li>
+    <li><a href="#enter-uv-rust-to-the-rescue">Enter uv: Rust to the Rescue</a></li>
+    <li><a href="#the-irony">The Irony</a></li>
+    <li><a href="#what-this-means">What This Means</a></li>
+    <li><a href="#my-post-on-linked-in">My post on linked-in</a></li>
+  </ul>
+</nav>
+        </div>
+    </details>
+</div>
+
+  <div class="post-content"><p>Well, well, well. Here we are in 2025 and Python packaging has finally been
+fixed. Not by the Python community, mind you - they had their shot for about
+20 years. No, it took the Rust folks to come in and show us how it&rsquo;s done.</p>
+<h2 id="the-long-painful-history">The Long, Painful History<a hidden class="anchor" aria-hidden="true" href="#the-long-painful-history">#</a></h2>
+<p>Let me paint you a picture. Back when I was starting out, we had <code>distutils</code>.
+That was it. Then came <code>setuptools</code>, which was supposed to fix everything.
+Then <code>pip</code> showed up to handle installation. Then <code>virtualenv</code> because global
+package installs were a nightmare. Then <code>pipenv</code> to combine pip and
+virtualenv. Then <code>poetry</code> because pipenv wasn&rsquo;t quite right. Then <code>pip-tools</code>
+for deterministic builds. Then <code>conda</code> for scientific computing. Then&hellip;</p>
+<p>You get the idea. Each tool solved one specific problem while creating three
+new ones. The Python community spent decades bikeshedding over package
+formats, dependency resolution algorithms, and lock file formats while the
+rest of the world just wanted to install packages without breaking their
+system. Some tools even managed to break the ancient Unix standard of
+shebang lines - you know, that <code>#!/usr/bin/env python</code> thing that&rsquo;s been
+working since the dawn of time.</p>
+<h2 id="the-delusion">The Delusion<a hidden class="anchor" aria-hidden="true" href="#the-delusion">#</a></h2>
+<p>Here&rsquo;s the thing that drives me nuts: the Python community kept insisting
+they could solve this from within. &ldquo;We just need better standards!&rdquo; they&rsquo;d
+cry. &ldquo;PEP 517 will fix everything!&rdquo; Narrator: it didn&rsquo;t. &ldquo;PEP 621 is the
+answer!&rdquo; Still waiting on that revolution.</p>
+<p>Meanwhile, every other modern language figured this out ages ago.
+<a href="https://doc.rust-lang.org/cargo/">Cargo</a> for
+<a href="https://www.rust-lang.org/">Rust</a>. <a href="https://go.dev/ref/mod">Go modules</a>.
+<a href="https://www.npmjs.com/">npm</a> (despite its flaws) for
+<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript">JavaScript</a>. Even
+Perl got <a href="https://www.cpan.org/">CPAN</a> right decades ago! But Python? Python
+kept spawning new tools that partially solved the problem while maintaining
+backward compatibility with decades of technical debt.</p>
+<h2 id="enter-uv-rust-to-the-rescue">Enter uv: Rust to the Rescue<a hidden class="anchor" aria-hidden="true" href="#enter-uv-rust-to-the-rescue">#</a></h2>
+<p>Then along comes <a href="https://astral.sh/">Astral</a> with
+<a href="https://docs.astral.sh/uv/"><code>uv</code></a>, written in
+<a href="https://www.rust-lang.org/">Rust</a>, and suddenly everything just&hellip; works.
+It&rsquo;s fast. Like, stupidly fast. It handles virtual environments
+transparently. It resolves dependencies without making you wait for your
+coffee to brew. It installs packages so quickly you wonder if it actually did
+anything.</p>
+<p>The best part? They didn&rsquo;t try to be compatible with every broken decision
+the Python packaging ecosystem made over the past two decades. They looked at
+what actually needed to be solved and built a tool that solves those
+problems.</p>
+<h2 id="the-irony">The Irony<a hidden class="anchor" aria-hidden="true" href="#the-irony">#</a></h2>
+<p>The delicious irony here is that it took a systems programming language to
+fix a scripting language&rsquo;s package management. Rust&rsquo;s obsession with memory
+safety and performance optimization turns out to be exactly what Python&rsquo;s
+packaging ecosystem needed. Who could have predicted that?</p>
+<p>It&rsquo;s like watching someone struggle to open a jar for 20 years, refusing help
+from anyone, only to have their neighbor walk over with the right tool and
+pop it open in two seconds.</p>
+<h2 id="what-this-means">What This Means<a hidden class="anchor" aria-hidden="true" href="#what-this-means">#</a></h2>
+<p>For those of us who&rsquo;ve been dealing with Python packaging hell since the
+<code>easy_install</code> days, <code>uv</code> feels like a miracle. One tool that does
+everything, does it fast, and doesn&rsquo;t break when you look at it sideways.
+Release engineers everywhere can finally sleep soundly knowing their builds
+won&rsquo;t randomly break because of dependency resolution conflicts or virtual
+environment corruption.</p>
+<p>The Python community should probably feel a little embarrassed about this.
+Twenty years of &ldquo;we can fix this ourselves&rdquo; only to be shown up by a tool
+written in a different language entirely. But hey, at least we finally have
+something that works.</p>
+<p>So here&rsquo;s to the Rust community for doing what the Python community couldn&rsquo;t:
+fixing Python packaging. Sometimes you need an outsider&rsquo;s perspective to see
+the forest for the trees. Or in this case, to see the solution through all
+the PEPs.</p>
+<p>Now if you&rsquo;ll excuse me, I need to go update all my projects to use <code>uv</code>. It
+only takes about 30 seconds per project, which is another miracle in itself.
+The best part? My colleagues independently discovered <code>uv</code> around the same
+time I did - that&rsquo;s how you know a tool is genuinely solving real problems
+when multiple people stumble across it organically.</p>
+<h2 id="my-post-on-linked-in">My post on linked-in<a hidden class="anchor" aria-hidden="true" href="#my-post-on-linked-in">#</a></h2>
+<ul>
+<li>coming soon</li>
+</ul>
+
+
+  </div>
+
+  <footer class="post-footer">
+    <ul class="post-tags">
+    </ul>
+
+<ul class="share-buttons">
+    <li>
+        <a target="_blank" rel="noopener noreferrer" aria-label="share How Rust Had to Save Python From Itself: The uv Revolution on linkedin"
+            href="https://www.linkedin.com/shareArticle?mini=true&amp;url=%2fposts%2f2025-09-04-uv-is-awesome%2f&amp;title=How%20Rust%20Had%20to%20Save%20Python%20From%20Itself%3a%20The%20uv%20Revolution&amp;summary=How%20Rust%20Had%20to%20Save%20Python%20From%20Itself%3a%20The%20uv%20Revolution&amp;source=%2fposts%2f2025-09-04-uv-is-awesome%2f">
+            <svg version="1.1" viewBox="0 0 512 512" xml:space="preserve" height="30px" width="30px" fill="currentColor">
+                <path
+                    d="M449.446,0c34.525,0 62.554,28.03 62.554,62.554l0,386.892c0,34.524 -28.03,62.554 -62.554,62.554l-386.892,0c-34.524,0 -62.554,-28.03 -62.554,-62.554l0,-386.892c0,-34.524 28.029,-62.554 62.554,-62.554l386.892,0Zm-288.985,423.278l0,-225.717l-75.04,0l0,225.717l75.04,0Zm270.539,0l0,-129.439c0,-69.333 -37.018,-101.586 -86.381,-101.586c-39.804,0 -57.634,21.891 -67.617,37.266l0,-31.958l-75.021,0c0.995,21.181 0,225.717 0,225.717l75.02,0l0,-126.056c0,-6.748 0.486,-13.492 2.474,-18.315c5.414,-13.475 17.767,-27.434 38.494,-27.434c27.135,0 38.007,20.707 38.007,51.037l0,120.768l75.024,0Zm-307.552,-334.556c-25.674,0 -42.448,16.879 -42.448,39.002c0,21.658 16.264,39.002 41.455,39.002l0.484,0c26.165,0 42.452,-17.344 42.452,-39.002c-0.485,-22.092 -16.241,-38.954 -41.943,-39.002Z" />
+            </svg>
+        </a>
+    </li>
+    <li>
+        <a target="_blank" rel="noopener noreferrer" aria-label="share How Rust Had to Save Python From Itself: The uv Revolution on reddit"
+            href="https://reddit.com/submit?url=%2fposts%2f2025-09-04-uv-is-awesome%2f&title=How%20Rust%20Had%20to%20Save%20Python%20From%20Itself%3a%20The%20uv%20Revolution">
+            <svg version="1.1" viewBox="0 0 512 512" xml:space="preserve" height="30px" width="30px" fill="currentColor">
+                <path
+                    d="M449.446,0c34.525,0 62.554,28.03 62.554,62.554l0,386.892c0,34.524 -28.03,62.554 -62.554,62.554l-386.892,0c-34.524,0 -62.554,-28.03 -62.554,-62.554l0,-386.892c0,-34.524 28.029,-62.554 62.554,-62.554l386.892,0Zm-3.446,265.638c0,-22.964 -18.616,-41.58 -41.58,-41.58c-11.211,0 -21.361,4.457 -28.841,11.666c-28.424,-20.508 -67.586,-33.757 -111.204,-35.278l18.941,-89.121l61.884,13.157c0.756,15.734 13.642,28.29 29.56,28.29c16.407,0 29.706,-13.299 29.706,-29.701c0,-16.403 -13.299,-29.702 -29.706,-29.702c-11.666,0 -21.657,6.792 -26.515,16.578l-69.105,-14.69c-1.922,-0.418 -3.939,-0.042 -5.585,1.036c-1.658,1.073 -2.811,2.761 -3.224,4.686l-21.152,99.438c-44.258,1.228 -84.046,14.494 -112.837,35.232c-7.468,-7.164 -17.589,-11.591 -28.757,-11.591c-22.965,0 -41.585,18.616 -41.585,41.58c0,16.896 10.095,31.41 24.568,37.918c-0.639,4.135 -0.99,8.328 -0.99,12.576c0,63.977 74.469,115.836 166.33,115.836c91.861,0 166.334,-51.859 166.334,-115.836c0,-4.218 -0.347,-8.387 -0.977,-12.493c14.564,-6.47 24.735,-21.034 24.735,-38.001Zm-119.474,108.193c-20.27,20.241 -59.115,21.816 -70.534,21.816c-11.428,0 -50.277,-1.575 -70.522,-21.82c-3.007,-3.008 -3.007,-7.882 0,-10.889c3.003,-2.999 7.882,-3.003 10.885,0c12.777,12.781 40.11,17.317 59.637,17.317c19.522,0 46.86,-4.536 59.657,-17.321c3.016,-2.999 7.886,-2.995 10.885,0.008c3.008,3.011 3.003,7.882 -0.008,10.889Zm-5.23,-48.781c-16.373,0 -29.701,-13.324 -29.701,-29.698c0,-16.381 13.328,-29.714 29.701,-29.714c16.378,0 29.706,13.333 29.706,29.714c0,16.374 -13.328,29.698 -29.706,29.698Zm-160.386,-29.702c0,-16.381 13.328,-29.71 29.714,-29.71c16.369,0 29.689,13.329 29.689,29.71c0,16.373 -13.32,29.693 -29.689,29.693c-16.386,0 -29.714,-13.32 -29.714,-29.693Z" />
+            </svg>
+        </a>
+    </li>
+    <li>
+        <a target="_blank" rel="noopener noreferrer" aria-label="share How Rust Had to Save Python From Itself: The uv Revolution on facebook"
+            href="https://facebook.com/sharer/sharer.php?u=%2fposts%2f2025-09-04-uv-is-awesome%2f">
+            <svg version="1.1" viewBox="0 0 512 512" xml:space="preserve" height="30px" width="30px" fill="currentColor">
+                <path
+                    d="M449.446,0c34.525,0 62.554,28.03 62.554,62.554l0,386.892c0,34.524 -28.03,62.554 -62.554,62.554l-106.468,0l0,-192.915l66.6,0l12.672,-82.621l-79.272,0l0,-53.617c0,-22.603 11.073,-44.636 46.58,-44.636l36.042,0l0,-70.34c0,0 -32.71,-5.582 -63.982,-5.582c-65.288,0 -107.96,39.569 -107.96,111.204l0,62.971l-72.573,0l0,82.621l72.573,0l0,192.915l-191.104,0c-34.524,0 -62.554,-28.03 -62.554,-62.554l0,-386.892c0,-34.524 28.029,-62.554 62.554,-62.554l386.892,0Z" />
+            </svg>
+        </a>
+    </li>
+    <li>
+        <a target="_blank" rel="noopener noreferrer" aria-label="share How Rust Had to Save Python From Itself: The uv Revolution on whatsapp"
+            href="https://api.whatsapp.com/send?text=How%20Rust%20Had%20to%20Save%20Python%20From%20Itself%3a%20The%20uv%20Revolution%20-%20%2fposts%2f2025-09-04-uv-is-awesome%2f">
+            <svg version="1.1" viewBox="0 0 512 512" xml:space="preserve" height="30px" width="30px" fill="currentColor">
+                <path
+                    d="M449.446,0c34.525,0 62.554,28.03 62.554,62.554l0,386.892c0,34.524 -28.03,62.554 -62.554,62.554l-386.892,0c-34.524,0 -62.554,-28.03 -62.554,-62.554l0,-386.892c0,-34.524 28.029,-62.554 62.554,-62.554l386.892,0Zm-58.673,127.703c-33.842,-33.881 -78.847,-52.548 -126.798,-52.568c-98.799,0 -179.21,80.405 -179.249,179.234c-0.013,31.593 8.241,62.428 23.927,89.612l-25.429,92.884l95.021,-24.925c26.181,14.28 55.659,21.807 85.658,21.816l0.074,0c98.789,0 179.206,-80.413 179.247,-179.243c0.018,-47.895 -18.61,-92.93 -52.451,-126.81Zm-126.797,275.782l-0.06,0c-26.734,-0.01 -52.954,-7.193 -75.828,-20.767l-5.441,-3.229l-56.386,14.792l15.05,-54.977l-3.542,-5.637c-14.913,-23.72 -22.791,-51.136 -22.779,-79.287c0.033,-82.142 66.867,-148.971 149.046,-148.971c39.793,0.014 77.199,15.531 105.329,43.692c28.128,28.16 43.609,65.592 43.594,105.4c-0.034,82.149 -66.866,148.983 -148.983,148.984Zm81.721,-111.581c-4.479,-2.242 -26.499,-13.075 -30.604,-14.571c-4.105,-1.495 -7.091,-2.241 -10.077,2.241c-2.986,4.483 -11.569,14.572 -14.182,17.562c-2.612,2.988 -5.225,3.364 -9.703,1.12c-4.479,-2.241 -18.91,-6.97 -36.017,-22.23c-13.314,-11.876 -22.304,-26.542 -24.916,-31.026c-2.612,-4.484 -0.279,-6.908 1.963,-9.14c2.016,-2.007 4.48,-5.232 6.719,-7.847c2.24,-2.615 2.986,-4.484 4.479,-7.472c1.493,-2.99 0.747,-5.604 -0.374,-7.846c-1.119,-2.241 -10.077,-24.288 -13.809,-33.256c-3.635,-8.733 -7.327,-7.55 -10.077,-7.688c-2.609,-0.13 -5.598,-0.158 -8.583,-0.158c-2.986,0 -7.839,1.121 -11.944,5.604c-4.105,4.484 -15.675,15.32 -15.675,37.364c0,22.046 16.048,43.342 18.287,46.332c2.24,2.99 31.582,48.227 76.511,67.627c10.685,4.615 19.028,7.371 25.533,9.434c10.728,3.41 20.492,2.929 28.209,1.775c8.605,-1.285 26.499,-10.833 30.231,-21.295c3.732,-10.464 3.732,-19.431 2.612,-21.298c-1.119,-1.869 -4.105,-2.99 -8.583,-5.232Z" />
+            </svg>
+        </a>
+    </li>
+    <li>
+        <a target="_blank" rel="noopener noreferrer" aria-label="share How Rust Had to Save Python From Itself: The uv Revolution on telegram"
+            href="https://telegram.me/share/url?text=How%20Rust%20Had%20to%20Save%20Python%20From%20Itself%3a%20The%20uv%20Revolution&amp;url=%2fposts%2f2025-09-04-uv-is-awesome%2f">
+            <svg version="1.1" xml:space="preserve" viewBox="2 2 28 28" height="30px" width="30px" fill="currentColor">
+                <path
+                    d="M26.49,29.86H5.5a3.37,3.37,0,0,1-2.47-1,3.35,3.35,0,0,1-1-2.47V5.48A3.36,3.36,0,0,1,3,3,3.37,3.37,0,0,1,5.5,2h21A3.38,3.38,0,0,1,29,3a3.36,3.36,0,0,1,1,2.46V26.37a3.35,3.35,0,0,1-1,2.47A3.38,3.38,0,0,1,26.49,29.86Zm-5.38-6.71a.79.79,0,0,0,.85-.66L24.73,9.24a.55.55,0,0,0-.18-.46.62.62,0,0,0-.41-.17q-.08,0-16.53,6.11a.59.59,0,0,0-.41.59.57.57,0,0,0,.43.52l4,1.24,1.61,4.83a.62.62,0,0,0,.63.43.56.56,0,0,0,.4-.17L16.54,20l4.09,3A.9.9,0,0,0,21.11,23.15ZM13.8,20.71l-1.21-4q8.72-5.55,8.78-5.55c.15,0,.23,0,.23.16a.18.18,0,0,1,0,.06s-2.51,2.3-7.52,6.8Z" />
+            </svg>
+        </a>
+    </li>
+    <li>
+        <a target="_blank" rel="noopener noreferrer" aria-label="share How Rust Had to Save Python From Itself: The uv Revolution on ycombinator"
+            href="https://news.ycombinator.com/submitlink?t=How%20Rust%20Had%20to%20Save%20Python%20From%20Itself%3a%20The%20uv%20Revolution&u=%2fposts%2f2025-09-04-uv-is-awesome%2f">
+            <svg version="1.1" xml:space="preserve" width="30px" height="30px" viewBox="0 0 512 512" fill="currentColor"
+                xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape">
+                <path
+                    d="M449.446 0C483.971 0 512 28.03 512 62.554L512 449.446C512 483.97 483.97 512 449.446 512L62.554 512C28.03 512 0 483.97 0 449.446L0 62.554C0 28.03 28.029 0 62.554 0L449.446 0ZM183.8767 87.9921H121.8427L230.6673 292.4508V424.0079H281.3328V292.4508L390.1575 87.9921H328.1233L256 238.2489z" />
+            </svg>
+        </a>
+    </li>
+</ul>
+
+  </footer>
+</article>
+    </main>
+    
+<footer class="footer">
+        <span>&copy; 2025 <a href="/">Christopher Hicks</a></span> · 
+
+    <span>
+        Powered by
+        <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo</a> &
+        <a href="https://github.com/adityatelange/hugo-PaperMod/" rel="noopener" target="_blank">PaperMod</a>
+    </span>
+</footer>
+<a href="#top" aria-label="go to top" title="Go to Top (Alt + G)" class="top-link" id="top-link" accesskey="g">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 6" fill="currentColor">
+        <path d="M12 6H0l6-6z" />
+    </svg>
+</a>
+
+<script>
+    let menu = document.getElementById('menu')
+    if (menu) {
+        menu.scrollLeft = localStorage.getItem("menu-scroll-position");
+        menu.onscroll = function () {
+            localStorage.setItem("menu-scroll-position", menu.scrollLeft);
+        }
+    }
+
+    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+        anchor.addEventListener("click", function (e) {
+            e.preventDefault();
+            var id = this.getAttribute("href").substr(1);
+            if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                document.querySelector(`[id='${decodeURIComponent(id)}']`).scrollIntoView({
+                    behavior: "smooth"
+                });
+            } else {
+                document.querySelector(`[id='${decodeURIComponent(id)}']`).scrollIntoView();
+            }
+            if (id === "top") {
+                history.replaceState(null, null, " ");
+            } else {
+                history.pushState(null, null, `#${id}`);
+            }
+        });
+    });
+
+</script>
+<script>
+    var mybutton = document.getElementById("top-link");
+    window.onscroll = function () {
+        if (document.body.scrollTop > 800 || document.documentElement.scrollTop > 800) {
+            mybutton.style.visibility = "visible";
+            mybutton.style.opacity = "1";
+        } else {
+            mybutton.style.visibility = "hidden";
+            mybutton.style.opacity = "0";
+        }
+    };
+
+</script>
+<script>
+    document.getElementById("theme-toggle").addEventListener("click", () => {
+        if (document.body.className.includes("dark")) {
+            document.body.classList.remove('dark');
+            localStorage.setItem("pref-theme", 'light');
+        } else {
+            document.body.classList.add('dark');
+            localStorage.setItem("pref-theme", 'dark');
+        }
+    })
+
+</script>
+</body>
+
+</html>

--- a/public/posts/index.html
+++ b/public/posts/index.html
@@ -154,6 +154,20 @@
 
 <article class="post-entry"> 
   <header class="entry-header">
+    <h2 class="entry-hint-parent">How Rust Had to Save Python From Itself: The uv Revolution
+    </h2>
+  </header>
+  <div class="entry-content">
+    <p>Well, well, well. Here we are in 2025 and Python packaging has finally been fixed. Not by the Python community, mind you - they had their shot for about 20 years. No, it took the Rust folks to come in and show us how it’s done.
+The Long, Painful History Let me paint you a picture. Back when I was starting out, we had distutils. That was it. Then came setuptools, which was supposed to fix everything. Then pip showed up to handle installation. Then virtualenv because global package installs were a nightmare. Then pipenv to combine pip and virtualenv. Then poetry because pipenv wasn’t quite right. Then pip-tools for deterministic builds. Then conda for scientific computing. Then…
+...</p>
+  </div>
+  <footer class="entry-footer"><span title='2025-09-04 00:00:00 +0000 UTC'>September 4, 2025</span>&nbsp;·&nbsp;4 min&nbsp;·&nbsp;673 words&nbsp;·&nbsp;Christopher Hicks</footer>
+  <a class="entry-link" aria-label="post link to How Rust Had to Save Python From Itself: The uv Revolution" href="/posts/2025-09-04-uv-is-awesome/"></a>
+</article>
+
+<article class="post-entry"> 
+  <header class="entry-header">
     <h2 class="entry-hint-parent">John Schreiber passed on July 29th, 2025
     </h2>
   </header>
@@ -285,21 +299,6 @@ There are a few things I wish I had included, particularly more on decorators li
   </div>
   <footer class="entry-footer"><span title='2024-09-29 15:39:41 -0700 PDT'>September 29, 2024</span>&nbsp;·&nbsp;2 min&nbsp;·&nbsp;295 words&nbsp;·&nbsp;Christopher Hicks</footer>
   <a class="entry-link" aria-label="post link to Using just to speed development" href="/posts/2024-09-29-using-just-to-speed-development/"></a>
-</article>
-
-<article class="post-entry"> 
-  <header class="entry-header">
-    <h2 class="entry-hint-parent">The Onion is back in print!
-    </h2>
-  </header>
-  <div class="entry-content">
-    <p>I am so pleased to see that my favorite news weekly (The Economist) has decided to cover the icon of American journalism we all know and love: The Onion!
-The Ecoonomist and The Onion are probably in distinctly different categories in most people’s minds. The Onion is clearly satire and The Economist is clearly sober, serious news. Right? It is not so easy actually.
-The Onion covers news with humor and does not limit itself to the facts. Facts have become so much less fashionable in American politics lately, so their choice probably won’t prevent The Onion from continuing to grow like a bean or prevent random publications from reprinting their articles as real news. And then The Economist also covers the news. The Economist does maintain factuality quite earnestly, but it isn’t afraid to poke fun at silly leadership or appreciate the humor readily apparent in our crazy world.
-...</p>
-  </div>
-  <footer class="entry-footer"><span title='2024-09-09 11:43:56 -0700 PDT'>September 9, 2024</span>&nbsp;·&nbsp;2 min&nbsp;·&nbsp;269 words&nbsp;·&nbsp;Christopher Hicks</footer>
-  <a class="entry-link" aria-label="post link to The Onion is back in print!" href="/posts/2024-09-09-onion-back-in-print/"></a>
 </article>
 <footer class="page-footer">
   <nav class="pagination">

--- a/public/posts/index.xml
+++ b/public/posts/index.xml
@@ -4,10 +4,17 @@
     <title>Posts on Christopher Hicks</title>
     <link>/posts/</link>
     <description>Recent content in Posts on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
-    <lastBuildDate>Fri, 22 Aug 2025 00:00:00 +0000</lastBuildDate>
+    <lastBuildDate>Thu, 04 Sep 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="/posts/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>How Rust Had to Save Python From Itself: The uv Revolution</title>
+      <link>/posts/2025-09-04-uv-is-awesome/</link>
+      <pubDate>Thu, 04 Sep 2025 00:00:00 +0000</pubDate>
+      <guid>/posts/2025-09-04-uv-is-awesome/</guid>
+      <description>Rust saves the bacon for python packaging and formatting.</description>
+    </item>
     <item>
       <title>John Schreiber passed on July 29th, 2025</title>
       <link>/posts/2025-08-24-john-schreiber-has-passed/</link>

--- a/public/posts/page/2/index.html
+++ b/public/posts/page/2/index.html
@@ -153,6 +153,21 @@
 </header>
 
 <article class="post-entry"> 
+  <header class="entry-header">
+    <h2 class="entry-hint-parent">The Onion is back in print!
+    </h2>
+  </header>
+  <div class="entry-content">
+    <p>I am so pleased to see that my favorite news weekly (The Economist) has decided to cover the icon of American journalism we all know and love: The Onion!
+The Ecoonomist and The Onion are probably in distinctly different categories in most people’s minds. The Onion is clearly satire and The Economist is clearly sober, serious news. Right? It is not so easy actually.
+The Onion covers news with humor and does not limit itself to the facts. Facts have become so much less fashionable in American politics lately, so their choice probably won’t prevent The Onion from continuing to grow like a bean or prevent random publications from reprinting their articles as real news. And then The Economist also covers the news. The Economist does maintain factuality quite earnestly, but it isn’t afraid to poke fun at silly leadership or appreciate the humor readily apparent in our crazy world.
+...</p>
+  </div>
+  <footer class="entry-footer"><span title='2024-09-09 11:43:56 -0700 PDT'>September 9, 2024</span>&nbsp;·&nbsp;2 min&nbsp;·&nbsp;269 words&nbsp;·&nbsp;Christopher Hicks</footer>
+  <a class="entry-link" aria-label="post link to The Onion is back in print!" href="/posts/2024-09-09-onion-back-in-print/"></a>
+</article>
+
+<article class="post-entry"> 
 <figure class="entry-cover">
         <img loading="lazy" src="/posts/2024-07-31-neckties-of-july.jpg" alt="">
 </figure>
@@ -285,26 +300,6 @@ Peter Jackson’s decision to make Get Back an eight-hour series rather than a t
   </div>
   <footer class="entry-footer"><span title='2023-09-02 17:48:32 +0000 UTC'>September 2, 2023</span>&nbsp;·&nbsp;1 min&nbsp;·&nbsp;38 words&nbsp;·&nbsp;Christopher Hicks</footer>
   <a class="entry-link" aria-label="post link to I&#39;m the new Observability Lead at Tubi" href="/posts/2023-09-02_174832_linkedin/"></a>
-</article>
-
-<article class="post-entry"> 
-<figure class="entry-cover">
-        <img loading="lazy" src="/posts/2023-07-23-community.png" alt="">
-</figure>
-  <header class="entry-header">
-    <h2 class="entry-hint-parent">Chicks on Community
-    </h2>
-  </header>
-  <div class="entry-content">
-    <p>Introduction Howdy there, Internet People.
-I am known as “chicks” and I’m here today to talk about the Internet and community.
-Background First, a little of my story to set the stage.
-I started in the computer business before there was a web browser, but conveniently the Internet blew up at the right time for me and it has kept me employed or consulting steadily for 30 years.
-In my formative years the computer business had a variety of thriving magazines. You could read in Wired or ComputerWorld how tech companies were striving to maximize their number of users by building a community and taking advantage of network effects.
-...</p>
-  </div>
-  <footer class="entry-footer"><span title='2023-07-24 00:00:00 +0000 UTC'>July 24, 2023</span>&nbsp;·&nbsp;6 min&nbsp;·&nbsp;1103 words&nbsp;·&nbsp;Christopher Hicks</footer>
-  <a class="entry-link" aria-label="post link to Chicks on Community" href="/posts/2023-07-23-community/"></a>
 </article>
 <footer class="page-footer">
   <nav class="pagination">

--- a/public/posts/page/3/index.html
+++ b/public/posts/page/3/index.html
@@ -153,6 +153,26 @@
 </header>
 
 <article class="post-entry"> 
+<figure class="entry-cover">
+        <img loading="lazy" src="/posts/2023-07-23-community.png" alt="">
+</figure>
+  <header class="entry-header">
+    <h2 class="entry-hint-parent">Chicks on Community
+    </h2>
+  </header>
+  <div class="entry-content">
+    <p>Introduction Howdy there, Internet People.
+I am known as “chicks” and I’m here today to talk about the Internet and community.
+Background First, a little of my story to set the stage.
+I started in the computer business before there was a web browser, but conveniently the Internet blew up at the right time for me and it has kept me employed or consulting steadily for 30 years.
+In my formative years the computer business had a variety of thriving magazines. You could read in Wired or ComputerWorld how tech companies were striving to maximize their number of users by building a community and taking advantage of network effects.
+...</p>
+  </div>
+  <footer class="entry-footer"><span title='2023-07-24 00:00:00 +0000 UTC'>July 24, 2023</span>&nbsp;·&nbsp;6 min&nbsp;·&nbsp;1103 words&nbsp;·&nbsp;Christopher Hicks</footer>
+  <a class="entry-link" aria-label="post link to Chicks on Community" href="/posts/2023-07-23-community/"></a>
+</article>
+
+<article class="post-entry"> 
   <header class="entry-header">
     <h2 class="entry-hint-parent">Tubi is competing with subscription services
     </h2>
@@ -278,19 +298,6 @@ If you are past the point where CreditKarma is giving you helpful information th
   </div>
   <footer class="entry-footer"><span title='2013-09-27 15:03:04 +0000 UTC'>September 27, 2013</span>&nbsp;·&nbsp;1 min&nbsp;·&nbsp;6 words&nbsp;·&nbsp;Christopher Hicks</footer>
   <a class="entry-link" aria-label="post link to VCs Should Give Honest Feedback & Why They Often Don’t" href="/posts/2013-09-27_150304_linkedin/"></a>
-</article>
-
-<article class="post-entry"> 
-  <header class="entry-header">
-    <h2 class="entry-hint-parent">Amazon CEO Jeff Bezos Had His Top Execs Read These Three Books
-    </h2>
-  </header>
-  <div class="entry-content">
-    <p>I shared https://www.linkedin.com/pulse/20130925133311-291225-amazon-ceo-jeff-bezos-had-his-top-execs-read-these-three-books/ by Jon Fortt, CNBC Anchor.
-</p>
-  </div>
-  <footer class="entry-footer"><span title='2013-09-26 12:03:57 +0000 UTC'>September 26, 2013</span>&nbsp;·&nbsp;1 min&nbsp;·&nbsp;8 words&nbsp;·&nbsp;Christopher Hicks</footer>
-  <a class="entry-link" aria-label="post link to Amazon CEO Jeff Bezos Had His Top Execs Read These Three Books" href="/posts/2013-09-26_120357_linkedin/"></a>
 </article>
 <footer class="page-footer">
   <nav class="pagination">

--- a/public/posts/page/4/index.html
+++ b/public/posts/page/4/index.html
@@ -154,6 +154,19 @@
 
 <article class="post-entry"> 
   <header class="entry-header">
+    <h2 class="entry-hint-parent">Amazon CEO Jeff Bezos Had His Top Execs Read These Three Books
+    </h2>
+  </header>
+  <div class="entry-content">
+    <p>I shared https://www.linkedin.com/pulse/20130925133311-291225-amazon-ceo-jeff-bezos-had-his-top-execs-read-these-three-books/ by Jon Fortt, CNBC Anchor.
+</p>
+  </div>
+  <footer class="entry-footer"><span title='2013-09-26 12:03:57 +0000 UTC'>September 26, 2013</span>&nbsp;·&nbsp;1 min&nbsp;·&nbsp;8 words&nbsp;·&nbsp;Christopher Hicks</footer>
+  <a class="entry-link" aria-label="post link to Amazon CEO Jeff Bezos Had His Top Execs Read These Three Books" href="/posts/2013-09-26_120357_linkedin/"></a>
+</article>
+
+<article class="post-entry"> 
+  <header class="entry-header">
     <h2 class="entry-hint-parent">Miley Cyrus’ Best Career Move. Ever.
     </h2>
   </header>
@@ -268,19 +281,6 @@
   </div>
   <footer class="entry-footer"><span title='2013-05-30 14:22:30 +0000 UTC'>May 30, 2013</span>&nbsp;·&nbsp;1 min&nbsp;·&nbsp;6 words&nbsp;·&nbsp;Christopher Hicks</footer>
   <a class="entry-link" aria-label="post link to What if you learned about personal branding from the greats?" href="/posts/2013-05-30_142230_linkedin/"></a>
-</article>
-
-<article class="post-entry"> 
-  <header class="entry-header">
-    <h2 class="entry-hint-parent">Your Most Important Career Decision
-    </h2>
-  </header>
-  <div class="entry-content">
-    <p>Linked to https://www.linkedin.com/pulse/20130422125441-201849-your-most-important-career-decision/ by Aaron Hurst.
-</p>
-  </div>
-  <footer class="entry-footer"><span title='2013-04-23 13:29:22 +0000 UTC'>April 23, 2013</span>&nbsp;·&nbsp;1 min&nbsp;·&nbsp;6 words&nbsp;·&nbsp;Christopher Hicks</footer>
-  <a class="entry-link" aria-label="post link to Your Most Important Career Decision" href="/posts/2013-04-23_132922_linkedin/"></a>
 </article>
 <footer class="page-footer">
   <nav class="pagination">

--- a/public/posts/page/5/index.html
+++ b/public/posts/page/5/index.html
@@ -154,6 +154,19 @@
 
 <article class="post-entry"> 
   <header class="entry-header">
+    <h2 class="entry-hint-parent">Your Most Important Career Decision
+    </h2>
+  </header>
+  <div class="entry-content">
+    <p>Linked to https://www.linkedin.com/pulse/20130422125441-201849-your-most-important-career-decision/ by Aaron Hurst.
+</p>
+  </div>
+  <footer class="entry-footer"><span title='2013-04-23 13:29:22 +0000 UTC'>April 23, 2013</span>&nbsp;·&nbsp;1 min&nbsp;·&nbsp;6 words&nbsp;·&nbsp;Christopher Hicks</footer>
+  <a class="entry-link" aria-label="post link to Your Most Important Career Decision" href="/posts/2013-04-23_132922_linkedin/"></a>
+</article>
+
+<article class="post-entry"> 
+  <header class="entry-header">
     <h2 class="entry-hint-parent">Arduinio Hackathon at OpenX Pasadena announcement
     </h2>
   </header>
@@ -279,21 +292,6 @@ http://www.inc.com/magazine/201209/jason-fried/why-company-a-month-off.html
   </div>
   <footer class="entry-footer"><span title='2012-10-17 15:22:25 +0000 UTC'>October 17, 2012</span>&nbsp;·&nbsp;1 min&nbsp;·&nbsp;22 words&nbsp;·&nbsp;Christopher Hicks</footer>
   <a class="entry-link" aria-label="post link to A month to yourself" href="/posts/2012-10-17_152225_linkedin/"></a>
-</article>
-
-<article class="post-entry"> 
-  <header class="entry-header">
-    <h2 class="entry-hint-parent">Why does spam get archived in hours?
-    </h2>
-  </header>
-  <div class="entry-content">
-    <p>Why does spam get archived in hours?
-Repeatedly across numerous groups I try to flag spam in Linked-In groups and I find that the message is already archived. I only found out about these posts because of the daily Linked-In emails, so these posts are being archived in less than a day, often in single digit hours. How could this be?
-The link associated with this post was meant to be an example, but the message board post is http://www.linkedin.com/groupAnswers?viewQuestionAndAnswers=&amp;discussionID=134866365&amp;gid=1268377&amp;trk=eml-anet_dig-b_nd-pst_ttle-cn&amp;ut=0WocEMpkIQr5k1
-...</p>
-  </div>
-  <footer class="entry-footer"><span title='2012-07-17 12:35:39 +0000 UTC'>July 17, 2012</span>&nbsp;·&nbsp;1 min&nbsp;·&nbsp;186 words&nbsp;·&nbsp;Christopher Hicks</footer>
-  <a class="entry-link" aria-label="post link to Why does spam get archived in hours?" href="/posts/2012-07-17_123539_linkedin/"></a>
 </article>
 <footer class="page-footer">
   <nav class="pagination">

--- a/public/posts/page/6/index.html
+++ b/public/posts/page/6/index.html
@@ -154,6 +154,21 @@
 
 <article class="post-entry"> 
   <header class="entry-header">
+    <h2 class="entry-hint-parent">Why does spam get archived in hours?
+    </h2>
+  </header>
+  <div class="entry-content">
+    <p>Why does spam get archived in hours?
+Repeatedly across numerous groups I try to flag spam in Linked-In groups and I find that the message is already archived. I only found out about these posts because of the daily Linked-In emails, so these posts are being archived in less than a day, often in single digit hours. How could this be?
+The link associated with this post was meant to be an example, but the message board post is http://www.linkedin.com/groupAnswers?viewQuestionAndAnswers=&amp;discussionID=134866365&amp;gid=1268377&amp;trk=eml-anet_dig-b_nd-pst_ttle-cn&amp;ut=0WocEMpkIQr5k1
+...</p>
+  </div>
+  <footer class="entry-footer"><span title='2012-07-17 12:35:39 +0000 UTC'>July 17, 2012</span>&nbsp;·&nbsp;1 min&nbsp;·&nbsp;186 words&nbsp;·&nbsp;Christopher Hicks</footer>
+  <a class="entry-link" aria-label="post link to Why does spam get archived in hours?" href="/posts/2012-07-17_123539_linkedin/"></a>
+</article>
+
+<article class="post-entry"> 
+  <header class="entry-header">
     <h2 class="entry-hint-parent">Defunct job post
     </h2>
   </header>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,6 +2,12 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
+    <loc>/posts/2025-09-04-uv-is-awesome/</loc>
+    <lastmod>2025-09-04T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>/posts/</loc>
+    <lastmod>2025-09-04T00:00:00+00:00</lastmod>
+  </url><url>
     <loc>/tags/ca-san-francisco/</loc>
     <lastmod>2025-08-22T00:00:00+00:00</lastmod>
   </url><url>
@@ -9,9 +15,6 @@
     <lastmod>2025-08-22T00:00:00+00:00</lastmod>
   </url><url>
     <loc>/posts/2025-08-24-john-schreiber-has-passed/</loc>
-    <lastmod>2025-08-22T00:00:00+00:00</lastmod>
-  </url><url>
-    <loc>/posts/</loc>
     <lastmod>2025-08-22T00:00:00+00:00</lastmod>
   </url><url>
     <loc>/tags/</loc>

--- a/public/tags/amazon/index.xml
+++ b/public/tags/amazon/index.xml
@@ -4,7 +4,7 @@
     <title>Amazon on Christopher Hicks</title>
     <link>/tags/amazon/</link>
     <description>Recent content in Amazon on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Thu, 26 Sep 2013 12:03:57 +0000</lastBuildDate>
     <atom:link href="/tags/amazon/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/arduino/index.xml
+++ b/public/tags/arduino/index.xml
@@ -4,7 +4,7 @@
     <title>Arduino on Christopher Hicks</title>
     <link>/tags/arduino/</link>
     <description>Recent content in Arduino on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Wed, 17 Apr 2013 12:49:49 +0000</lastBuildDate>
     <atom:link href="/tags/arduino/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/art/index.xml
+++ b/public/tags/art/index.xml
@@ -4,7 +4,7 @@
     <title>Art on Christopher Hicks</title>
     <link>/tags/art/</link>
     <description>Recent content in Art on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Wed, 25 Jun 2025 12:00:00 -0400</lastBuildDate>
     <atom:link href="/tags/art/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/billiards/index.xml
+++ b/public/tags/billiards/index.xml
@@ -4,7 +4,7 @@
     <title>Billiards on Christopher Hicks</title>
     <link>/tags/billiards/</link>
     <description>Recent content in Billiards on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 12 Jul 2024 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/billiards/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/book/index.xml
+++ b/public/tags/book/index.xml
@@ -4,7 +4,7 @@
     <title>Book on Christopher Hicks</title>
     <link>/tags/book/</link>
     <description>Recent content in Book on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Thu, 26 Sep 2013 12:03:57 +0000</lastBuildDate>
     <atom:link href="/tags/book/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/branding/index.xml
+++ b/public/tags/branding/index.xml
@@ -4,7 +4,7 @@
     <title>Branding on Christopher Hicks</title>
     <link>/tags/branding/</link>
     <description>Recent content in Branding on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Tue, 02 Jul 2024 10:53:43 -0700</lastBuildDate>
     <atom:link href="/tags/branding/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/business/index.xml
+++ b/public/tags/business/index.xml
@@ -4,7 +4,7 @@
     <title>Business on Christopher Hicks</title>
     <link>/tags/business/</link>
     <description>Recent content in Business on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 16 May 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/business/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/ca-central-coast/index.xml
+++ b/public/tags/ca-central-coast/index.xml
@@ -4,7 +4,7 @@
     <title>Ca-Central-Coast on Christopher Hicks</title>
     <link>/tags/ca-central-coast/</link>
     <description>Recent content in Ca-Central-Coast on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Sun, 09 Jul 2023 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/ca-central-coast/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/ca-san-francisco/index.xml
+++ b/public/tags/ca-san-francisco/index.xml
@@ -4,7 +4,7 @@
     <title>Ca-San-Francisco on Christopher Hicks</title>
     <link>/tags/ca-san-francisco/</link>
     <description>Recent content in Ca-San-Francisco on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 22 Aug 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/ca-san-francisco/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/cloud/index.xml
+++ b/public/tags/cloud/index.xml
@@ -4,7 +4,7 @@
     <title>Cloud on Christopher Hicks</title>
     <link>/tags/cloud/</link>
     <description>Recent content in Cloud on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 16 May 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/cloud/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/creativity/index.xml
+++ b/public/tags/creativity/index.xml
@@ -4,7 +4,7 @@
     <title>Creativity on Christopher Hicks</title>
     <link>/tags/creativity/</link>
     <description>Recent content in Creativity on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 13 Jun 2025 07:40:44 -0400</lastBuildDate>
     <atom:link href="/tags/creativity/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/data-center/index.xml
+++ b/public/tags/data-center/index.xml
@@ -4,7 +4,7 @@
     <title>Data-Center on Christopher Hicks</title>
     <link>/tags/data-center/</link>
     <description>Recent content in Data-Center on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Sat, 15 Oct 2011 12:19:40 +0000</lastBuildDate>
     <atom:link href="/tags/data-center/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/database/index.xml
+++ b/public/tags/database/index.xml
@@ -4,7 +4,7 @@
     <title>Database on Christopher Hicks</title>
     <link>/tags/database/</link>
     <description>Recent content in Database on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 16 May 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/database/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/dead-link/index.xml
+++ b/public/tags/dead-link/index.xml
@@ -4,7 +4,7 @@
     <title>Dead-Link on Christopher Hicks</title>
     <link>/tags/dead-link/</link>
     <description>Recent content in Dead-Link on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Mon, 11 Nov 2013 15:00:02 +0000</lastBuildDate>
     <atom:link href="/tags/dead-link/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/family/index.xml
+++ b/public/tags/family/index.xml
@@ -4,7 +4,7 @@
     <title>Family on Christopher Hicks</title>
     <link>/tags/family/</link>
     <description>Recent content in Family on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 22 Aug 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/family/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/finance/index.xml
+++ b/public/tags/finance/index.xml
@@ -4,7 +4,7 @@
     <title>Finance on Christopher Hicks</title>
     <link>/tags/finance/</link>
     <description>Recent content in Finance on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Wed, 24 Oct 2018 15:15:30 +0000</lastBuildDate>
     <atom:link href="/tags/finance/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/fini-edge-reports/index.xml
+++ b/public/tags/fini-edge-reports/index.xml
@@ -4,7 +4,7 @@
     <title>Fini-Edge-Reports on Christopher Hicks</title>
     <link>/tags/fini-edge-reports/</link>
     <description>Recent content in Fini-Edge-Reports on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Mon, 15 Nov 1999 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/fini-edge-reports/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/free-software/index.xml
+++ b/public/tags/free-software/index.xml
@@ -4,7 +4,7 @@
     <title>Free-Software on Christopher Hicks</title>
     <link>/tags/free-software/</link>
     <description>Recent content in Free-Software on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 16 May 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/free-software/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/gaming/index.xml
+++ b/public/tags/gaming/index.xml
@@ -4,7 +4,7 @@
     <title>Gaming on Christopher Hicks</title>
     <link>/tags/gaming/</link>
     <description>Recent content in Gaming on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 10 May 2024 20:30:19 +0000</lastBuildDate>
     <atom:link href="/tags/gaming/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/habits/index.xml
+++ b/public/tags/habits/index.xml
@@ -4,7 +4,7 @@
     <title>Habits on Christopher Hicks</title>
     <link>/tags/habits/</link>
     <description>Recent content in Habits on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 02 May 2025 08:00:00 -0700</lastBuildDate>
     <atom:link href="/tags/habits/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/history/index.xml
+++ b/public/tags/history/index.xml
@@ -4,7 +4,7 @@
     <title>History on Christopher Hicks</title>
     <link>/tags/history/</link>
     <description>Recent content in History on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 13 Jun 2025 07:40:44 -0400</lastBuildDate>
     <atom:link href="/tags/history/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/hugo/index.xml
+++ b/public/tags/hugo/index.xml
@@ -4,7 +4,7 @@
     <title>Hugo on Christopher Hicks</title>
     <link>/tags/hugo/</link>
     <description>Recent content in Hugo on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Tue, 02 Jul 2024 10:53:43 -0700</lastBuildDate>
     <atom:link href="/tags/hugo/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/humor/index.xml
+++ b/public/tags/humor/index.xml
@@ -4,7 +4,7 @@
     <title>Humor on Christopher Hicks</title>
     <link>/tags/humor/</link>
     <description>Recent content in Humor on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Mon, 09 Sep 2024 11:43:56 -0700</lastBuildDate>
     <atom:link href="/tags/humor/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/index.xml
+++ b/public/tags/index.xml
@@ -4,7 +4,7 @@
     <title>Tags on Christopher Hicks</title>
     <link>/tags/</link>
     <description>Recent content in Tags on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 22 Aug 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/keyboard/index.xml
+++ b/public/tags/keyboard/index.xml
@@ -4,7 +4,7 @@
     <title>Keyboard on Christopher Hicks</title>
     <link>/tags/keyboard/</link>
     <description>Recent content in Keyboard on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Thu, 13 Jun 2024 17:01:26 +0000</lastBuildDate>
     <atom:link href="/tags/keyboard/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/lego/index.xml
+++ b/public/tags/lego/index.xml
@@ -4,7 +4,7 @@
     <title>Lego on Christopher Hicks</title>
     <link>/tags/lego/</link>
     <description>Recent content in Lego on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Mon, 22 Sep 2014 16:17:41 +0000</lastBuildDate>
     <atom:link href="/tags/lego/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/linked-in/index.xml
+++ b/public/tags/linked-in/index.xml
@@ -4,7 +4,7 @@
     <title>Linked-In on Christopher Hicks</title>
     <link>/tags/linked-in/</link>
     <description>Recent content in Linked-In on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 22 Apr 2022 14:56:04 +0000</lastBuildDate>
     <atom:link href="/tags/linked-in/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/linux/index.xml
+++ b/public/tags/linux/index.xml
@@ -4,7 +4,7 @@
     <title>Linux on Christopher Hicks</title>
     <link>/tags/linux/</link>
     <description>Recent content in Linux on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Sun, 06 Jun 1999 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/linux/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/mcdtechlab/index.xml
+++ b/public/tags/mcdtechlab/index.xml
@@ -4,7 +4,7 @@
     <title>Mcdtechlab on Christopher Hicks</title>
     <link>/tags/mcdtechlab/</link>
     <description>Recent content in Mcdtechlab on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Mon, 30 Nov 2020 16:48:46 +0000</lastBuildDate>
     <atom:link href="/tags/mcdtechlab/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/microsoft/index.xml
+++ b/public/tags/microsoft/index.xml
@@ -4,7 +4,7 @@
     <title>Microsoft on Christopher Hicks</title>
     <link>/tags/microsoft/</link>
     <description>Recent content in Microsoft on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Sun, 11 Jun 2023 15:36:43 +0000</lastBuildDate>
     <atom:link href="/tags/microsoft/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/mobile/index.xml
+++ b/public/tags/mobile/index.xml
@@ -4,7 +4,7 @@
     <title>Mobile on Christopher Hicks</title>
     <link>/tags/mobile/</link>
     <description>Recent content in Mobile on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 22 Apr 2022 14:56:04 +0000</lastBuildDate>
     <atom:link href="/tags/mobile/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/openx/index.xml
+++ b/public/tags/openx/index.xml
@@ -4,7 +4,7 @@
     <title>Openx on Christopher Hicks</title>
     <link>/tags/openx/</link>
     <description>Recent content in Openx on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Wed, 17 Apr 2013 12:49:49 +0000</lastBuildDate>
     <atom:link href="/tags/openx/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/organization/index.xml
+++ b/public/tags/organization/index.xml
@@ -4,7 +4,7 @@
     <title>Organization on Christopher Hicks</title>
     <link>/tags/organization/</link>
     <description>Recent content in Organization on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 02 May 2025 08:00:00 -0700</lastBuildDate>
     <atom:link href="/tags/organization/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/recruitment/index.xml
+++ b/public/tags/recruitment/index.xml
@@ -4,7 +4,7 @@
     <title>Recruitment on Christopher Hicks</title>
     <link>/tags/recruitment/</link>
     <description>Recent content in Recruitment on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Tue, 23 Apr 2013 13:29:22 +0000</lastBuildDate>
     <atom:link href="/tags/recruitment/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/redhat/index.xml
+++ b/public/tags/redhat/index.xml
@@ -4,7 +4,7 @@
     <title>Redhat on Christopher Hicks</title>
     <link>/tags/redhat/</link>
     <description>Recent content in Redhat on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Mon, 24 Jul 2023 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/redhat/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/refer/index.xml
+++ b/public/tags/refer/index.xml
@@ -4,7 +4,7 @@
     <title>Refer on Christopher Hicks</title>
     <link>/tags/refer/</link>
     <description>Recent content in Refer on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Wed, 24 Oct 2018 15:15:30 +0000</lastBuildDate>
     <atom:link href="/tags/refer/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/review/index.xml
+++ b/public/tags/review/index.xml
@@ -4,7 +4,7 @@
     <title>Review on Christopher Hicks</title>
     <link>/tags/review/</link>
     <description>Recent content in Review on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Mon, 10 Mar 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/review/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/slack/index.xml
+++ b/public/tags/slack/index.xml
@@ -4,7 +4,7 @@
     <title>Slack on Christopher Hicks</title>
     <link>/tags/slack/</link>
     <description>Recent content in Slack on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 02 May 2025 08:00:00 -0700</lastBuildDate>
     <atom:link href="/tags/slack/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/the-economist/index.xml
+++ b/public/tags/the-economist/index.xml
@@ -4,7 +4,7 @@
     <title>The-Economist on Christopher Hicks</title>
     <link>/tags/the-economist/</link>
     <description>Recent content in The-Economist on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Mon, 09 Sep 2024 11:43:56 -0700</lastBuildDate>
     <atom:link href="/tags/the-economist/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/training/index.xml
+++ b/public/tags/training/index.xml
@@ -4,7 +4,7 @@
     <title>Training on Christopher Hicks</title>
     <link>/tags/training/</link>
     <description>Recent content in Training on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 29 Jul 2011 00:43:50 +0000</lastBuildDate>
     <atom:link href="/tags/training/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/trains/index.xml
+++ b/public/tags/trains/index.xml
@@ -4,7 +4,7 @@
     <title>Trains on Christopher Hicks</title>
     <link>/tags/trains/</link>
     <description>Recent content in Trains on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 13 Jun 2025 07:40:44 -0400</lastBuildDate>
     <atom:link href="/tags/trains/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/travel/index.xml
+++ b/public/tags/travel/index.xml
@@ -4,7 +4,7 @@
     <title>Travel on Christopher Hicks</title>
     <link>/tags/travel/</link>
     <description>Recent content in Travel on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Wed, 31 Jul 2024 11:06:18 -0700</lastBuildDate>
     <atom:link href="/tags/travel/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/tubi/index.xml
+++ b/public/tags/tubi/index.xml
@@ -4,7 +4,7 @@
     <title>Tubi on Christopher Hicks</title>
     <link>/tags/tubi/</link>
     <description>Recent content in Tubi on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Mon, 10 Feb 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/tubi/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/va-lee-hall/index.xml
+++ b/public/tags/va-lee-hall/index.xml
@@ -4,7 +4,7 @@
     <title>Va-Lee-Hall on Christopher Hicks</title>
     <link>/tags/va-lee-hall/</link>
     <description>Recent content in Va-Lee-Hall on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 25 Apr 2025 08:29:13 -0400</lastBuildDate>
     <atom:link href="/tags/va-lee-hall/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/va-williamsburg/index.xml
+++ b/public/tags/va-williamsburg/index.xml
@@ -4,7 +4,7 @@
     <title>Va-Williamsburg on Christopher Hicks</title>
     <link>/tags/va-williamsburg/</link>
     <description>Recent content in Va-Williamsburg on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Wed, 25 Jun 2025 12:00:00 -0400</lastBuildDate>
     <atom:link href="/tags/va-williamsburg/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/virtu/index.xml
+++ b/public/tags/virtu/index.xml
@@ -4,7 +4,7 @@
     <title>Virtu on Christopher Hicks</title>
     <link>/tags/virtu/</link>
     <description>Recent content in Virtu on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Tue, 16 Jul 2013 02:03:02 +0000</lastBuildDate>
     <atom:link href="/tags/virtu/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/wired/index.xml
+++ b/public/tags/wired/index.xml
@@ -4,7 +4,7 @@
     <title>Wired on Christopher Hicks</title>
     <link>/tags/wired/</link>
     <description>Recent content in Wired on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Mon, 30 Nov 2020 16:48:46 +0000</lastBuildDate>
     <atom:link href="/tags/wired/index.xml" rel="self" type="application/rss+xml" />

--- a/public/tags/youtube/index.xml
+++ b/public/tags/youtube/index.xml
@@ -4,7 +4,7 @@
     <title>Youtube on Christopher Hicks</title>
     <link>/tags/youtube/</link>
     <description>Recent content in Youtube on Christopher Hicks</description>
-    <generator>Hugo -- 0.148.1</generator>
+    <generator>Hugo -- 0.149.0</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 22 Aug 2025 00:00:00 +0000</lastBuildDate>
     <atom:link href="/tags/youtube/index.xml" rel="self" type="application/rss+xml" />


### PR DESCRIPTION
## Done:

- 🐐 [post] How Rust Had to Save Python From Itself: The uv Revolution


(Automated in `justfile`.)
