### PR TITLE
🤛 [just] add "just hugo force" to ignore "public.prev" leftovers

### DIFF
--- a/.just/hugo.just
+++ b/.just/hugo.just
@@ -12,12 +12,17 @@ hugo_mod_update:
 
 # run hugo from the top of the repo
 [group('Hugo')]
-hugo:
+hugo force='':
     #!/usr/bin/env bash
     PREV_DIR="public.prev"
     if [[ -e "$PREV_DIR" ]]; then
         echo "{{RED}}The $PREV_DIR directory exists.  Is there a bug on a previous hugo run?{{NORMAL}}"
-        exit 5
+        if [[ -n "{{force}}" ]]; then
+            echo "{{BLUE}}But we can recreate it and hope for the best!{{NORMAL}}"
+            rm -rf "$PREV_DIR"
+        else
+            exit 5
+        fi
     fi
     echo "{{GREEN}}no $PREV_DIR directory, so safe to rebuild with hugo...{{NORMAL}}"
 


### PR DESCRIPTION
## Pull Request Overview
This PR adds a force parameter to the hugo task in the justfile to allow bypassing the safety check that prevents hugo from running when a public.prev directory exists from a previous incomplete run.

- Adds an optional force parameter to the hugo task
- Implements logic to remove the public.prev directory when force is enabled
- Maintains existing safety behavior as the default when force is not specified