### PR TITLE
💡 [gha] run lighthouses in parallel

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -78,7 +78,7 @@ jobs:
       # new SHA partially restore (Chrome is reused if the version
       # matches; otherwise puppeteer re-downloads harmlessly).
       - name: Cache Chrome and action node_modules
-        uses: actions/cache@5a3a84c0d7af23f35252957c5e1c141c7e3c9c7c # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cache/puppeteer

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -33,11 +33,27 @@ permissions: {}
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
-    # numberOfRuns: 3 across 5 URLs = 15 Lighthouse audits; bound a hang
-    # well below GitHub's 360-minute default to fail fast.
-    timeout-minutes: 15
+    # Each matrix job runs numberOfRuns (3) Lighthouse audits against a
+    # single URL; bound a hang well below GitHub's 360-minute default.
+    timeout-minutes: 6
     permissions:
       contents: read
+    strategy:
+      # Let every URL finish so we see all failures at once rather than
+      # aborting siblings on the first regression.
+      fail-fast: false
+      matrix:
+        # Canonical URL list for Lighthouse audits. If a post is renamed
+        # or removed, update its entry here (and only here).
+        url:
+          - http://localhost/
+          - http://localhost/posts/
+          # Deliberate representative single-post audit; if this post is
+          # renamed or removed, swap in another content-rich post so the
+          # audit doesn't silently 404.
+          - http://localhost/posts/2026-06-06-shell-programming-best-practices/
+          - http://localhost/intro/
+          - http://localhost/links/
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       # We intentionally audit the committed ./public directory rather than
@@ -46,13 +62,14 @@ jobs:
       # won't reach the server anyway — auditing stale HTML would just
       # mask that mismatch. See link-check.yml for a workflow that does
       # build on the fly.
-      - name: Audit static site with Lighthouse
+      - name: Audit ${{ matrix.url }} with Lighthouse
         # Pinned to the commit the v12 tag points at; third-party actions
         # should not be trusted on a mutable floating tag.
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
         with:
-          # lighthouserc.json declares the curated URL list and ./public
-          # as the static distribution directory to audit.
+          # The URL to audit comes from the matrix; lighthouserc.json
+          # supplies staticDistDir, numberOfRuns, and assertions.
+          urls: ${{ matrix.url }}
           configPath: ./lighthouserc.json
           uploadArtifacts: true
           # Uploads the HTML report to treosh's third-party temporary

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -62,6 +62,9 @@ jobs:
           - /posts/2026-06-06-shell-programming-best-practices/
           - /intro/
           - /links/
+          - /links/brag/
+          - /reference/
+          - /tags/
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       # We intentionally audit the committed ./public directory rather than

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -74,20 +74,6 @@ jobs:
       # mask that mismatch. See link-check.yml for a workflow that does
       # build on the fly.
 
-      # Cache the treosh action's node_modules so we skip its runtime
-      # `npm install` on cache hits. The action depends on puppeteer-core
-      # (not puppeteer), which never downloads Chrome — it uses the
-      # Chrome pre-installed on the ubuntu-24.04 runner image, so there
-      # is no Puppeteer download cache to preserve. Keyed on the pinned
-      # action SHA; bumping the SHA invalidates automatically. The
-      # restore-keys fallback lets a new SHA partially restore.
-      - name: Cache action node_modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/work/_actions/treosh/lighthouse-ci-action/3e7e23fb74242897f95c0ba9cabad3d0227b9b18/node_modules
-          key: linux-lhci-3e7e23fb74242897f95c0ba9cabad3d0227b9b18
-          restore-keys: linux-lhci-
-
       # Fail loud if ./public is absent. The workflow is path-filtered on
       # public/** so this should never happen on a legit trigger, but a
       # silent skip would mask a real checkout/build regression as a green

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -86,8 +86,12 @@ jobs:
           key: linux-lhci-3e7e23fb74242897f95c0ba9cabad3d0227b9b18
           restore-keys: linux-lhci-
 
-      # Skip cleanly if a path-filter change (e.g. docs-only) somehow
-      # left public/ absent, rather than 404ing every audit.
+      # Fail loud if ./public is absent. The workflow is path-filtered on
+      # public/** so this should never happen on a legit trigger, but a
+      # silent skip would mask a real checkout/build regression as a green
+      # "Lighthouse CI" run. The public_dir output is still set so the
+      # downstream `if:` guards remain valid (and reachable only when
+      # present).
       - name: Guard public/ exists
         id: guard
         run: |
@@ -95,7 +99,8 @@ jobs:
             echo "public_dir=present" >> "$GITHUB_OUTPUT"
           else
             echo "public_dir=missing" >> "$GITHUB_OUTPUT"
-            echo "::warning::./public not found; skipping Lighthouse audit."
+            echo "::error::./public not found; cannot run Lighthouse audit." >&2
+            exit 1
           fi
 
       - name: Start static server

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -71,35 +71,19 @@ jobs:
       # mask that mismatch. See link-check.yml for a workflow that does
       # build on the fly.
 
-      # Cache the Puppeteer Chrome download (~150MB) and the action's
-      # node_modules so we skip re-fetching and re-installing them every
-      # job. Keyed on the pinned action SHA + OS; bumping the SHA
-      # invalidates automatically. The restore-keys fallback lets a
-      # new SHA partially restore (Chrome is reused if the version
-      # matches; otherwise puppeteer re-downloads harmlessly).
-      - name: Cache Chrome and action node_modules
+      # Cache the treosh action's node_modules so we skip its runtime
+      # `npm install` on cache hits. The action depends on puppeteer-core
+      # (not puppeteer), which never downloads Chrome — it uses the
+      # Chrome pre-installed on the ubuntu-24.04 runner image, so there
+      # is no Puppeteer download cache to preserve. Keyed on the pinned
+      # action SHA; bumping the SHA invalidates automatically. The
+      # restore-keys fallback lets a new SHA partially restore.
+      - name: Cache action node_modules
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          path: |
-            ~/.cache/puppeteer
-            ~/work/_actions/treosh/lighthouse-ci-action/3e7e23fb74242897f95c0ba9cabad3d0227b9b18/node_modules
+          path: ~/work/_actions/treosh/lighthouse-ci-action/3e7e23fb74242897f95c0ba9cabad3d0227b9b18/node_modules
           key: linux-lhci-3e7e23fb74242897f95c0ba9cabad3d0227b9b18
           restore-keys: linux-lhci-
-
-      # Temporary diagnostic: confirm whether the treosh action's
-      # node_modules path is actually populated by the cache above
-      # (concern #2 from the review). The treosh action ships a prebuilt
-      # dist/ and installs @lhci/cli at runtime, so this half of the
-      # cache may be a harmless no-op. Remove this step once confirmed.
-      - name: Debug cached paths
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "::group::~/.cache/puppeteer"
-          ls -la ~/.cache/puppeteer || true
-          echo "::endgroup::"
-          echo "::group::treosh action node_modules"
-          ls -la ~/work/_actions/treosh/lighthouse-ci-action/3e7e23fb74242897f95c0ba9cabad3d0227b9b18/node_modules || true
-          echo "::endgroup::"
 
       # Fail loud if ./public is absent. The workflow is path-filtered on
       # public/** so this should never happen on a legit trigger, but a

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -43,17 +43,25 @@ jobs:
       # aborting siblings on the first regression.
       fail-fast: false
       matrix:
-        # Canonical URL list for Lighthouse audits. If a post is renamed
-        # or removed, update its entry here (and only here).
-        url:
-          - http://localhost/
-          - http://localhost/posts/
+        # Path-only entries; the workflow prefixes them with the static
+        # server's origin (http://127.0.0.1:8080) and passes the full URL
+        # to the action via `urls:`. We intentionally do NOT use
+        # lighthouserc.json's staticDistDir here: the treosh action's
+        # collect logic is `if (staticDistDir) { --static-dist-dir }
+        # else if (urls) { --url }`, so staticDistDir would silently
+        # override --url and trigger LHCI's autodiscovery across all of
+        # ./public (maxAutodiscoverUrls=5), making every matrix job
+        # audit every URL. See commit history for the regression that
+        # motivated removing staticDistDir from the CI config.
+        path:
+          - /
+          - /posts/
           # Deliberate representative single-post audit; if this post is
           # renamed or removed, swap in another content-rich post so the
           # audit doesn't silently 404.
-          - http://localhost/posts/2026-06-06-shell-programming-best-practices/
-          - http://localhost/intro/
-          - http://localhost/links/
+          - /posts/2026-06-06-shell-programming-best-practices/
+          - /intro/
+          - /links/
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       # We intentionally audit the committed ./public directory rather than
@@ -62,17 +70,78 @@ jobs:
       # won't reach the server anyway — auditing stale HTML would just
       # mask that mismatch. See link-check.yml for a workflow that does
       # build on the fly.
-      - name: Audit ${{ matrix.url }} with Lighthouse
+
+      # Cache the Puppeteer Chrome download (~150MB) and the action's
+      # node_modules so we skip re-fetching and re-installing them every
+      # job. Keyed on the pinned action SHA + OS; bumping the SHA
+      # invalidates automatically. The restore-keys fallback lets a
+      # new SHA partially restore (Chrome is reused if the version
+      # matches; otherwise puppeteer re-downloads harmlessly).
+      - name: Cache Chrome and action node_modules
+        uses: actions/cache@5a3a84c0d7af23f35252957c5e1c141c7e3c9c7c # v4
+        with:
+          path: |
+            ~/.cache/puppeteer
+            ~/work/_actions/treosh/lighthouse-ci-action/3e7e23fb74242897f95c0ba9cabad3d0227b9b18/node_modules
+          key: linux-lhci-3e7e23fb74242897f95c0ba9cabad3d0227b9b18
+          restore-keys: linux-lhci-
+
+      # Skip cleanly if a path-filter change (e.g. docs-only) somehow
+      # left public/ absent, rather than 404ing every audit.
+      - name: Guard public/ exists
+        id: guard
+        run: |
+          if [ -d ./public ]; then
+            echo "public_dir=present" >> "$GITHUB_OUTPUT"
+          else
+            echo "public_dir=missing" >> "$GITHUB_OUTPUT"
+            echo "::warning::./public not found; skipping Lighthouse audit."
+          fi
+
+      - name: Start static server
+        if: steps.guard.outputs.public_dir == 'present'
+        run: |
+          python3 -m http.server 8080 --directory ./public --bind 127.0.0.1 \
+            > /tmp/lhci-server.log 2>&1 &
+          echo "SERVER_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for static server
+        if: steps.guard.outputs.public_dir == 'present'
+        run: |
+          for _ in $(seq 1 10); do
+            if curl --silent --fail --output /dev/null http://127.0.0.1:8080/; then
+              echo "Server is up."
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Static server did not become ready in 10s." >&2
+          cat /tmp/lhci-server.log >&2 || true
+          exit 1
+
+      - name: Audit http://127.0.0.1:8080${{ matrix.path }} with Lighthouse
+        if: steps.guard.outputs.public_dir == 'present'
         # Pinned to the commit the v12 tag points at; third-party actions
         # should not be trusted on a mutable floating tag.
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
         with:
-          # The URL to audit comes from the matrix; lighthouserc.json
-          # supplies staticDistDir, numberOfRuns, and assertions.
-          urls: ${{ matrix.url }}
+          # The URL to audit comes from the matrix (prefixed with the
+          # static server origin); lighthouserc.json supplies
+          # numberOfRuns and assertions. staticDistDir is deliberately
+          # absent from the config so the action takes the `urls` branch
+          # and passes --url, otherwise LHCI autodiscovers all URLs.
+          urls: http://127.0.0.1:8080${{ matrix.path }}
           configPath: ./lighthouserc.json
           uploadArtifacts: true
           # Uploads the HTML report to treosh's third-party temporary
           # public storage (unauthenticated, expires in a few days).
           # The site itself is public, so this is low risk.
           temporaryPublicStorage: true
+
+      - name: Stop static server
+        if: always() && steps.guard.outputs.public_dir == 'present'
+        run: |
+          if [ -n "${SERVER_PID:-}" ]; then
+            kill "$SERVER_PID" 2>/dev/null || true
+            wait "$SERVER_PID" 2>/dev/null || true
+          fi

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -86,6 +86,21 @@ jobs:
           key: linux-lhci-3e7e23fb74242897f95c0ba9cabad3d0227b9b18
           restore-keys: linux-lhci-
 
+      # Temporary diagnostic: confirm whether the treosh action's
+      # node_modules path is actually populated by the cache above
+      # (concern #2 from the review). The treosh action ships a prebuilt
+      # dist/ and installs @lhci/cli at runtime, so this half of the
+      # cache may be a harmless no-op. Remove this step once confirmed.
+      - name: Debug cached paths
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "::group::~/.cache/puppeteer"
+          ls -la ~/.cache/puppeteer || true
+          echo "::endgroup::"
+          echo "::group::treosh action node_modules"
+          ls -la ~/work/_actions/treosh/lighthouse-ci-action/3e7e23fb74242897f95c0ba9cabad3d0227b9b18/node_modules || true
+          echo "::endgroup::"
+
       # Fail loud if ./public is absent. The workflow is path-filtered on
       # public/** so this should never happen on a legit trigger, but a
       # silent skip would mask a real checkout/build regression as a green

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,7 +1,7 @@
 {
   "ci": {
     "collect": {
-      "staticDistDir": "./public",
+      "_comment": "CI-only config. staticDistDir is intentionally omitted so the GitHub Action passes --url per matrix job against a static server started in the workflow (see .github/workflows/lighthouse.yml). For local use, run: lhci collect --static-dist-dir=./public --numberOfRuns=3",
       "numberOfRuns": 3
     },
     "assert": {

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -2,14 +2,6 @@
   "ci": {
     "collect": {
       "staticDistDir": "./public",
-      "_comment": "The shell-programming-best-practices URL is a deliberate representative single-post audit; if that post is renamed or removed, update this entry to another content-rich post so the audit doesn't silently 404.",
-      "url": [
-        "http://localhost/",
-        "http://localhost/posts/",
-        "http://localhost/posts/2026-06-06-shell-programming-best-practices/",
-        "http://localhost/intro/",
-        "http://localhost/links/"
-      ],
       "numberOfRuns": 3
     },
     "assert": {


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 💡 [gha] run lighthouses in parallel
- lighthouse: remove staticDir and try caching
- 🔧 [gha] fix unresolvable actions/cache SHA in lighthouse workflow
- 🔧 [gha] hard-fail lighthouse when public/ is missing
- 🔍 [gha] add PR-only diagnostic for lighthouse cache paths
- lighthouse: simplify cache configuration since Chrome is already installed in Ubuntu
- lighthouse: 3 more pages to try in parallel
- lighthouse: remove ineffective node_modules cache

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
