### PR TITLE
🎾 [gha] fix truncated upload-artifact SHA in scorecards workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -68,7 +68,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@043fb46d1a93c77aae6567c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🎾 [gha] fix truncated upload-artifact SHA in scorecards workflow

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
